### PR TITLE
 Add machineID filter option to Get-MdeVulnerabilitybyMachine 

### DIFF
--- a/src/private/Invoke-AzureRequest.ps1
+++ b/src/private/Invoke-AzureRequest.ps1
@@ -4,6 +4,7 @@ function Invoke-AzureRequest {
     [string]
     $uri
   )
+  Write-Verbose "Calling following URI - $uri"
   $reply = Invoke-RetryRequest -Method Get -Uri $uri
   $content = $reply.value
   while (-not [String]::IsNullOrEmpty($reply.'@odata.nextLink')) {

--- a/src/public/Get-MdeVulnerabilityByMachine.ps1
+++ b/src/public/Get-MdeVulnerabilityByMachine.ps1
@@ -24,23 +24,42 @@
 function Get-MdeVulnerabilityByMachine {
   [CmdletBinding()]
   param (
-    [Parameter(ValueFromPipelineByPropertyName, ValueFromPipeline)]
+    [Parameter( ParameterSetName = 'Severity',ValueFromPipelineByPropertyName, ValueFromPipeline)]
     [ValidateSet("Low", "Medium", "High", "Critical")]  
     [string]
-    $severity
+    $severity,
+    [Parameter( ParameterSetName = 'MachineId',ValueFromPipelineByPropertyName, ValueFromPipeline)]
+    [string]
+    $machineId
+
   )
   Begin {
     if (-not (Test-MdePermissions -functionName $PSCmdlet.CommandRuntime)) {
       $requiredRoles = (Get-Help $PSCmdlet.CommandRuntime -Full).role | Invoke-Expression
       Throw "Missing required permission(s). Please check if one of these is in current token roles: $($requiredRoles.permission)"
     }
-    $uri = 'https://api.securitycenter.microsoft.com/api/vulnerabilities/machinesVulnerabilities{0}' -f ([String]::IsNullOrEmpty($severity) ? '' : "?`$filter=severity+eq+'$severity'")
+    
+    if($severity){
+
+      $filter = [String]::IsNullOrEmpty($severity) ? '' : "?`$filter=severity+eq+'$severity'"
+
+    }
+
+    if($machineId){
+      $filter = [String]::IsNullOrEmpty($machineId) ? '': "?`$filter=machineId+eq+'$machineId'"
+
+    }
+    
+    Write-Verbose "Results Filter $filter"
+
+    $uri = 'https://api.securitycenter.microsoft.com/api/vulnerabilities/machinesVulnerabilities{0}' -f ([String]::IsNullOrEmpty($filter) ? '' : "$filter")
   }
   Process {
     return Invoke-AzureRequest -Uri $uri
   }
   End {}
 }
+
 # SIG # Begin signature block
 # MIIVigYJKoZIhvcNAQcCoIIVezCCFXcCAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR


### PR DESCRIPTION
 Add machineID filter option to Get-MdeVulnerabilitybyMachine and aded addtional verbosity to Invoke-AzureRequest. We now can get all the vulnerabilities for a specfic machineid. THis is very helpful in larger environments