### PR TITLE
perf(invokeazurerequest): :zap: removed string concatenation

### DIFF
--- a/src/private/Invoke-AzureRequest.ps1
+++ b/src/private/Invoke-AzureRequest.ps1
@@ -5,12 +5,12 @@ function Invoke-AzureRequest {
     $uri
   )
   $reply = Invoke-RetryRequest -Method Get -Uri $uri
-  $content = $reply.value
+  $reply.value
   while (-not [String]::IsNullOrEmpty($reply.'@odata.nextLink')) {
     Write-Verbose "Found next link: $($reply.'@odata.nextLink')"
     $reply = Invoke-RetryRequest -Method Get -Uri $reply.'@odata.nextLink'
     foreach ($value in $reply.value) {
-      $content += $value
+      $value
     }
   }
   return $content


### PR DESCRIPTION
Much faster and far less memory usage through sending objects down the  pipeline rather than concatting strings. Discovered this perf issue when I was trying to use `Get-MDEMachine` in an environment with tens of thousands of enrolled machines.